### PR TITLE
fix: package exports and type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
   "version": "0.8.70",
   "license": "MIT",
-  "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./types": "./dist/index.d.ts"
+  },
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
# Bug
Vite apps failed while building with the SDK. Entry for the package was not well defined.
<details>
<summary>
Stack trace
</summary>


```tangled git:(feat/routerchain-integration) ✗ pnpm build:example

> @1.0.0 build:example /Users/j/Documents/GitHub/Work/tangled
> pnpm --filter @tangled3/example-react build


> @tangled3/example-react@0.0.0 build /Users/j/Documents/GitHub/Work/tangled/example
> tsc && vite build

vite v5.2.13 building for production...
src/components/Providers.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
✓ 79 modules transformed.
x Build failed in 458ms
error during build:
[commonjs--resolver] Failed to resolve entry for package "@routerprotocol/router-chain-sdk-ts". The package may have incorrect main/module/exports specified in its package.json.
    at packageEntryFailure (file:///Users/j/Documents/GitHub/Work/tangled/node_modules/.pnpm/vite@5.2.13_@types+node@20.14.14_lightningcss@1.27.0_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-DEPSZ3SS.js:49442:17)
    at resolvePackageEntry (file:///Users/j/Documents/GitHub/Work/tangled/node_modules/.pnpm/vite@5.2.13_@types+node@20.14.14_lightningcss@1.27.0_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-DEPSZ3SS.js:49439:5)
....
...

  
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @tangled3/example-react@0.0.0 build: `tsc && vite build`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
```
</details>

# Fix
Added `"type": "commonjs"` to `package.json` and added exports field to fix build on vite apps.

